### PR TITLE
SimpleCovを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 # gem
 /vendor
 
+#Code coverage
+coverage
+
 # jetbrains
 /.idea
 

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ group :development, :test do
 
   # Faker
   gem 'faker'
+
+  # Code coverage
+  gem 'simplecov', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
+    docile (1.3.5)
     enumerize (2.4.0)
       activesupport (>= 3.2)
     erubi (1.10.0)
@@ -229,6 +230,12 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -295,6 +302,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,11 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Code coverage
+require 'simplecov'
+SimpleCov.start
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
`$ bundle exec rspec`実行時に、テストコードがどれだけコードをカバーしているかを`coverage/`に出力してくれます。
<img width="1920" alt="スクリーンショット 2021-03-06 10 52 21" src="https://user-images.githubusercontent.com/54909391/110191059-09bdd100-7e6a-11eb-836a-a24fff2c035c.png">
