### PR TITLE
Change: docker-compose up時にerdではなくbundle installを実行する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN gem install bundler
 ADD ./Gemfile $APP_ROOT/Gemfile
 ADD ./Gemfile.lock $APP_ROOT/Gemfile.lock
 
-RUN bundle install
-
 # Entrykitをダウンロードし、実行できるように設定
 ENV ENTRYKIT_VERSION 0.4.0
 RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
@@ -25,7 +23,7 @@ RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERS
     && chmod +x /bin/entrykit \
     && entrykit --symlink
 
-# gem rails-erd を実行し、ER図を生成
-ENTRYPOINT ["prehook", "bundle exec erd", "--"]
+# docker-compose up を実行するたびにbundle installを実行する
+ENTRYPOINT ["prehook", "bundle install", "--"]
 
 ADD . $APP_ROOT


### PR DESCRIPTION
DB構造が大きく変化することは考えられないので、自動でerdを実行するentrykitは無効にする。
代わりに、bundle installを毎回実行する(gem 追加時にめんどいから)